### PR TITLE
Force the `use-strict` setup on node itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "start": "node --use-strict server.js",
-    "test": "node node_modules/jasmine/bin/jasmine.js"
+    "test": "node --use-strict node_modules/jasmine/bin/jasmine.js"
   },
   "license": "MIT"
 }

--- a/server.js
+++ b/server.js
@@ -1,5 +1,3 @@
-"use strict";
-
 const version = 'v0.2-alpha';
 const port = 8081;
 


### PR DESCRIPTION
Ainsi `npm start` et `npm test` sont bons.