### PR TITLE
Fix font bug for old version of firefox

### DIFF
--- a/public/api.ejs
+++ b/public/api.ejs
@@ -9,7 +9,7 @@
             }
 
             * {
-                font-family: 'Segoe UI Light', Tahoma, Geneva, Verdana, sans-serif;
+                font-family: 'Segoe UI', Tahoma, Geneva, Verdana, sans-serif;
                 box-sizing:border-box;
             }
 


### PR DESCRIPTION
The font are bolder but it's better for the readability and firefox (<=56.0) has the good font now